### PR TITLE
Fixed layout issue for multiple compared programs

### DIFF
--- a/app/components/Schedule.tsx
+++ b/app/components/Schedule.tsx
@@ -262,6 +262,7 @@ const Programs = styled.div`
     justify-content: space-between;
     align-items: center;
     width: 100%;
+    max-width: 64rem;
     height: 3rem;
     user-select: none;
 


### PR DESCRIPTION
A max-width contraint was not set for the sub-header, which caused a layout issue for the name of the program.